### PR TITLE
pin __archspec 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: base
 channels:
   - conda-forge
 dependencies:
+  - __archspec =1
   - ase =3.26.0
   - assyst =0.8.0  # [unix]
   - atomistics =0.3.0


### PR DESCRIPTION
conda info on cmti:
virtual packages : __archspec=1=cascadelake
                          __conda=24.9.2=0
                          __glibc=2.31=0
                          __linux=5.14.21=0
                          __unix=0=0