### PR TITLE
Revert "Added jupyter-ai version 3.0.0 to environment"

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,6 @@ dependencies:
 - jupyterlab =4.5.7
 - jupyter-server-proxy =4.4.0
 - jupyterhub =5.2.1
-- jupyter-ai =3.0.0
 - lammps =2024.08.29=*openmpi*
 - landau =1.7.0
 - langchain =1.2.18


### PR DESCRIPTION
Reverts pyiron/cmmc_env#207
It seems like this package drastically increases startup time. The environment with this included did not spawn a single-user-server in 40s...